### PR TITLE
transformation: using instanceClassName covers custom EDataTypes as well

### DIFF
--- a/transformation/src/fr/inria/atlanmod/mogwai/transformation/files/ocl2gremlin.asm
+++ b/transformation/src/fr/inria/atlanmod/mogwai/transformation/files/ocl2gremlin.asm
@@ -705,8 +705,6 @@
 		<constant value="317:4-317:68"/>
 		<constant value="320:3-323:4"/>
 		<constant value="__applyvarExp2steps"/>
-		<constant value="test"/>
-		<constant value="J.debug(J):J"/>
 		<constant value="321:12-321:18"/>
 		<constant value="321:12-321:35"/>
 		<constant value="321:12-321:40"/>
@@ -714,9 +712,7 @@
 		<constant value="321:4-321:48"/>
 		<constant value="322:19-322:25"/>
 		<constant value="322:19-322:40"/>
-		<constant value="322:47-322:53"/>
-		<constant value="322:19-322:54"/>
-		<constant value="322:4-322:54"/>
+		<constant value="322:4-322:40"/>
 		<constant value="__matchvarExpInCollect2steps"/>
 		<constant value="J.and(J):J"/>
 		<constant value="id"/>
@@ -731,12 +727,9 @@
 		<constant value="329:4-329:69"/>
 		<constant value="332:3-334:4"/>
 		<constant value="__applyvarExpInCollect2steps"/>
-		<constant value="aaaaaaaaaah"/>
 		<constant value="333:19-333:25"/>
 		<constant value="333:19-333:40"/>
-		<constant value="333:47-333:60"/>
-		<constant value="333:19-333:61"/>
-		<constant value="333:4-333:61"/>
+		<constant value="333:4-333:40"/>
 		<constant value="__matchpropertyRefCallExp2steps"/>
 		<constant value="PropertyCallExp"/>
 		<constant value="referredProperty"/>
@@ -843,11 +836,11 @@
 		<constant value="__matchpropertyAttBooleanLastInComparison2steps"/>
 		<constant value="instanceClassName"/>
 		<constant value="java.lang.Boolean"/>
-		<constant value="89"/>
+		<constant value="bool"/>
+		<constant value="96"/>
 		<constant value="transform"/>
 		<constant value="clos"/>
 		<constant value="closureIt"/>
-		<constant value="bool"/>
 		<constant value="StringLiteral"/>
 		<constant value="nextCall"/>
 		<constant value="405:4-405:8"/>
@@ -860,102 +853,118 @@
 		<constant value="406:44-406:57"/>
 		<constant value="406:4-406:58"/>
 		<constant value="405:4-406:58"/>
-		<constant value="407:4-407:8"/>
-		<constant value="407:4-407:25"/>
-		<constant value="407:4-407:31"/>
-		<constant value="407:4-407:49"/>
-		<constant value="407:52-407:71"/>
-		<constant value="407:4-407:71"/>
-		<constant value="405:4-407:71"/>
-		<constant value="408:4-408:8"/>
-		<constant value="408:4-408:29"/>
-		<constant value="405:4-408:29"/>
-		<constant value="411:3-414:4"/>
-		<constant value="415:3-418:4"/>
-		<constant value="419:3-421:4"/>
-		<constant value="422:3-425:4"/>
-		<constant value="426:3-428:4"/>
-		<constant value="429:3-431:4"/>
-		<constant value="432:3-434:4"/>
+		<constant value="407:5-407:9"/>
+		<constant value="407:5-407:26"/>
+		<constant value="407:5-407:32"/>
+		<constant value="407:5-407:50"/>
+		<constant value="407:53-407:72"/>
+		<constant value="407:5-407:72"/>
+		<constant value="408:8-408:12"/>
+		<constant value="408:8-408:29"/>
+		<constant value="408:8-408:35"/>
+		<constant value="408:8-408:53"/>
+		<constant value="408:56-408:62"/>
+		<constant value="408:8-408:62"/>
+		<constant value="407:5-408:62"/>
+		<constant value="405:4-408:63"/>
+		<constant value="409:4-409:8"/>
+		<constant value="409:4-409:29"/>
+		<constant value="405:4-409:29"/>
+		<constant value="412:3-415:4"/>
+		<constant value="416:3-419:4"/>
+		<constant value="420:3-422:4"/>
+		<constant value="423:3-426:4"/>
+		<constant value="427:3-429:4"/>
+		<constant value="430:3-432:4"/>
+		<constant value="433:3-435:4"/>
 		<constant value="__applypropertyAttBooleanLastInComparison2steps"/>
 		<constant value="true"/>
-		<constant value="412:12-412:16"/>
-		<constant value="412:12-412:33"/>
-		<constant value="412:12-412:38"/>
-		<constant value="412:4-412:38"/>
-		<constant value="413:19-413:28"/>
-		<constant value="413:4-413:28"/>
-		<constant value="416:15-416:19"/>
-		<constant value="416:4-416:19"/>
-		<constant value="417:19-417:27"/>
-		<constant value="417:4-417:27"/>
-		<constant value="420:20-420:22"/>
-		<constant value="420:4-420:22"/>
-		<constant value="423:12-423:21"/>
-		<constant value="423:4-423:21"/>
-		<constant value="424:13-424:17"/>
-		<constant value="424:4-424:17"/>
-		<constant value="430:13-430:19"/>
-		<constant value="430:4-430:19"/>
-		<constant value="433:19-433:23"/>
-		<constant value="433:19-433:38"/>
-		<constant value="433:4-433:38"/>
+		<constant value="413:12-413:16"/>
+		<constant value="413:12-413:33"/>
+		<constant value="413:12-413:38"/>
+		<constant value="413:4-413:38"/>
+		<constant value="414:19-414:28"/>
+		<constant value="414:4-414:28"/>
+		<constant value="417:15-417:19"/>
+		<constant value="417:4-417:19"/>
+		<constant value="418:19-418:27"/>
+		<constant value="418:4-418:27"/>
+		<constant value="421:20-421:22"/>
+		<constant value="421:4-421:22"/>
+		<constant value="424:12-424:21"/>
+		<constant value="424:4-424:21"/>
+		<constant value="425:13-425:17"/>
+		<constant value="425:4-425:17"/>
+		<constant value="431:13-431:19"/>
+		<constant value="431:4-431:19"/>
+		<constant value="434:19-434:23"/>
+		<constant value="434:19-434:38"/>
+		<constant value="434:4-434:38"/>
 		<constant value="__matchpropertyAttIntegerLastInComparison2steps"/>
 		<constant value="java.lang.Integer"/>
-		<constant value="440:4-440:8"/>
-		<constant value="440:4-440:25"/>
-		<constant value="440:38-440:52"/>
-		<constant value="440:4-440:53"/>
+		<constant value="int"/>
+		<constant value="60"/>
 		<constant value="441:4-441:8"/>
 		<constant value="441:4-441:25"/>
-		<constant value="441:4-441:31"/>
-		<constant value="441:44-441:57"/>
-		<constant value="441:4-441:58"/>
-		<constant value="440:4-441:58"/>
+		<constant value="441:38-441:52"/>
+		<constant value="441:4-441:53"/>
 		<constant value="442:4-442:8"/>
 		<constant value="442:4-442:25"/>
 		<constant value="442:4-442:31"/>
-		<constant value="442:4-442:49"/>
-		<constant value="442:52-442:71"/>
-		<constant value="442:4-442:71"/>
-		<constant value="440:4-442:71"/>
-		<constant value="443:4-443:8"/>
-		<constant value="443:4-443:29"/>
-		<constant value="440:4-443:29"/>
-		<constant value="446:3-448:4"/>
+		<constant value="442:44-442:57"/>
+		<constant value="442:4-442:58"/>
+		<constant value="441:4-442:58"/>
+		<constant value="443:5-443:9"/>
+		<constant value="443:5-443:26"/>
+		<constant value="443:5-443:32"/>
+		<constant value="443:5-443:50"/>
+		<constant value="443:53-443:72"/>
+		<constant value="443:5-443:72"/>
+		<constant value="444:8-444:12"/>
+		<constant value="444:8-444:29"/>
+		<constant value="444:8-444:35"/>
+		<constant value="444:8-444:53"/>
+		<constant value="444:56-444:61"/>
+		<constant value="444:8-444:61"/>
+		<constant value="443:5-444:61"/>
+		<constant value="441:4-444:62"/>
+		<constant value="445:4-445:8"/>
+		<constant value="445:4-445:29"/>
+		<constant value="441:4-445:29"/>
+		<constant value="448:3-450:4"/>
 		<constant value="__applypropertyAttIntegerLastInComparison2steps"/>
-		<constant value="447:12-447:16"/>
-		<constant value="447:12-447:33"/>
-		<constant value="447:12-447:38"/>
-		<constant value="447:4-447:38"/>
+		<constant value="449:12-449:16"/>
+		<constant value="449:12-449:33"/>
+		<constant value="449:12-449:38"/>
+		<constant value="449:4-449:38"/>
 		<constant value="__matchpropertyAttStringLastInComparison2steps"/>
 		<constant value="java.lang.String"/>
-		<constant value="454:4-454:8"/>
-		<constant value="454:4-454:25"/>
-		<constant value="454:38-454:52"/>
-		<constant value="454:4-454:53"/>
-		<constant value="455:4-455:8"/>
-		<constant value="455:4-455:25"/>
-		<constant value="455:4-455:31"/>
-		<constant value="455:44-455:57"/>
-		<constant value="455:4-455:58"/>
-		<constant value="454:4-455:58"/>
 		<constant value="456:4-456:8"/>
 		<constant value="456:4-456:25"/>
-		<constant value="456:4-456:31"/>
-		<constant value="456:4-456:49"/>
-		<constant value="456:52-456:70"/>
-		<constant value="456:4-456:70"/>
-		<constant value="454:4-456:70"/>
+		<constant value="456:38-456:52"/>
+		<constant value="456:4-456:53"/>
 		<constant value="457:4-457:8"/>
-		<constant value="457:4-457:29"/>
-		<constant value="454:4-457:29"/>
-		<constant value="460:3-462:4"/>
+		<constant value="457:4-457:25"/>
+		<constant value="457:4-457:31"/>
+		<constant value="457:44-457:57"/>
+		<constant value="457:4-457:58"/>
+		<constant value="456:4-457:58"/>
+		<constant value="458:4-458:8"/>
+		<constant value="458:4-458:25"/>
+		<constant value="458:4-458:31"/>
+		<constant value="458:4-458:49"/>
+		<constant value="458:52-458:70"/>
+		<constant value="458:4-458:70"/>
+		<constant value="456:4-458:70"/>
+		<constant value="459:4-459:8"/>
+		<constant value="459:4-459:29"/>
+		<constant value="456:4-459:29"/>
+		<constant value="462:3-464:4"/>
 		<constant value="__applypropertyAttStringLastInComparison2steps"/>
-		<constant value="461:12-461:16"/>
-		<constant value="461:12-461:33"/>
-		<constant value="461:12-461:38"/>
-		<constant value="461:4-461:38"/>
+		<constant value="463:12-463:16"/>
+		<constant value="463:12-463:33"/>
+		<constant value="463:12-463:38"/>
+		<constant value="463:4-463:38"/>
 	</cp>
 	<field name="1" type="2"/>
 	<field name="3" type="4"/>
@@ -3253,33 +3262,29 @@
 			<getasm/>
 			<load arg="29"/>
 			<call arg="544"/>
-			<push arg="704"/>
-			<call arg="705"/>
 			<call arg="30"/>
 			<set arg="475"/>
 			<pop/>
 		</code>
 		<linenumbertable>
-			<lne id="706" begin="11" end="11"/>
-			<lne id="707" begin="11" end="12"/>
-			<lne id="708" begin="11" end="13"/>
-			<lne id="709" begin="11" end="14"/>
-			<lne id="710" begin="9" end="16"/>
-			<lne id="711" begin="19" end="19"/>
-			<lne id="712" begin="19" end="20"/>
-			<lne id="713" begin="21" end="21"/>
-			<lne id="714" begin="19" end="22"/>
-			<lne id="715" begin="17" end="24"/>
-			<lne id="702" begin="8" end="25"/>
+			<lne id="704" begin="11" end="11"/>
+			<lne id="705" begin="11" end="12"/>
+			<lne id="706" begin="11" end="13"/>
+			<lne id="707" begin="11" end="14"/>
+			<lne id="708" begin="9" end="16"/>
+			<lne id="709" begin="19" end="19"/>
+			<lne id="710" begin="19" end="20"/>
+			<lne id="711" begin="17" end="22"/>
+			<lne id="702" begin="8" end="23"/>
 		</linenumbertable>
 		<localvariabletable>
-			<lve slot="3" name="692" begin="7" end="25"/>
-			<lve slot="2" name="691" begin="3" end="25"/>
-			<lve slot="0" name="17" begin="0" end="25"/>
-			<lve slot="1" name="463" begin="0" end="25"/>
+			<lve slot="3" name="692" begin="7" end="23"/>
+			<lve slot="2" name="691" begin="3" end="23"/>
+			<lve slot="0" name="17" begin="0" end="23"/>
+			<lve slot="1" name="463" begin="0" end="23"/>
 		</localvariabletable>
 	</operation>
-	<operation name="716">
+	<operation name="712">
 		<context type="6"/>
 		<parameters>
 		</parameters>
@@ -3299,7 +3304,7 @@
 			<push arg="17"/>
 			<call arg="158"/>
 			<call arg="555"/>
-			<call arg="717"/>
+			<call arg="713"/>
 			<call arg="155"/>
 			<if arg="690"/>
 			<getasm/>
@@ -3315,7 +3320,7 @@
 			<load arg="19"/>
 			<pcall arg="328"/>
 			<dup/>
-			<push arg="718"/>
+			<push arg="714"/>
 			<push arg="674"/>
 			<push arg="331"/>
 			<new/>
@@ -3325,23 +3330,23 @@
 			<enditerate/>
 		</code>
 		<linenumbertable>
-			<lne id="719" begin="7" end="7"/>
-			<lne id="720" begin="7" end="8"/>
-			<lne id="721" begin="9" end="9"/>
-			<lne id="722" begin="9" end="10"/>
-			<lne id="723" begin="9" end="11"/>
-			<lne id="724" begin="12" end="12"/>
-			<lne id="725" begin="9" end="13"/>
-			<lne id="726" begin="9" end="14"/>
-			<lne id="727" begin="7" end="15"/>
-			<lne id="728" begin="30" end="35"/>
+			<lne id="715" begin="7" end="7"/>
+			<lne id="716" begin="7" end="8"/>
+			<lne id="717" begin="9" end="9"/>
+			<lne id="718" begin="9" end="10"/>
+			<lne id="719" begin="9" end="11"/>
+			<lne id="720" begin="12" end="12"/>
+			<lne id="721" begin="9" end="13"/>
+			<lne id="722" begin="9" end="14"/>
+			<lne id="723" begin="7" end="15"/>
+			<lne id="724" begin="30" end="35"/>
 		</linenumbertable>
 		<localvariabletable>
 			<lve slot="1" name="691" begin="6" end="37"/>
 			<lve slot="0" name="17" begin="0" end="38"/>
 		</localvariabletable>
 	</operation>
-	<operation name="729">
+	<operation name="725">
 		<context type="6"/>
 		<parameters>
 			<parameter name="19" type="336"/>
@@ -3352,7 +3357,7 @@
 			<call arg="337"/>
 			<store arg="29"/>
 			<load arg="19"/>
-			<push arg="718"/>
+			<push arg="714"/>
 			<call arg="338"/>
 			<store arg="203"/>
 			<load arg="203"/>
@@ -3360,33 +3365,29 @@
 			<getasm/>
 			<load arg="29"/>
 			<call arg="544"/>
-			<push arg="730"/>
-			<call arg="705"/>
 			<call arg="30"/>
 			<set arg="475"/>
 			<pop/>
 		</code>
 		<linenumbertable>
-			<lne id="731" begin="11" end="11"/>
-			<lne id="732" begin="11" end="12"/>
-			<lne id="733" begin="13" end="13"/>
-			<lne id="734" begin="11" end="14"/>
-			<lne id="735" begin="9" end="16"/>
-			<lne id="728" begin="8" end="17"/>
+			<lne id="726" begin="11" end="11"/>
+			<lne id="727" begin="11" end="12"/>
+			<lne id="728" begin="9" end="14"/>
+			<lne id="724" begin="8" end="15"/>
 		</linenumbertable>
 		<localvariabletable>
-			<lve slot="3" name="718" begin="7" end="17"/>
-			<lve slot="2" name="691" begin="3" end="17"/>
-			<lve slot="0" name="17" begin="0" end="17"/>
-			<lve slot="1" name="463" begin="0" end="17"/>
+			<lve slot="3" name="714" begin="7" end="15"/>
+			<lve slot="2" name="691" begin="3" end="15"/>
+			<lve slot="0" name="17" begin="0" end="15"/>
+			<lve slot="1" name="463" begin="0" end="15"/>
 		</localvariabletable>
 	</operation>
-	<operation name="736">
+	<operation name="729">
 		<context type="6"/>
 		<parameters>
 		</parameters>
 		<code>
-			<push arg="737"/>
+			<push arg="730"/>
 			<push arg="91"/>
 			<findme/>
 			<push arg="323"/>
@@ -3394,17 +3395,17 @@
 			<iterate/>
 			<store arg="19"/>
 			<load arg="19"/>
-			<get arg="738"/>
-			<push arg="739"/>
+			<get arg="731"/>
+			<push arg="732"/>
 			<push arg="91"/>
 			<findme/>
 			<call arg="98"/>
 			<load arg="19"/>
-			<call arg="740"/>
+			<call arg="733"/>
 			<call arg="555"/>
-			<call arg="717"/>
+			<call arg="713"/>
 			<call arg="155"/>
-			<if arg="741"/>
+			<if arg="734"/>
 			<getasm/>
 			<get arg="1"/>
 			<push arg="325"/>
@@ -3414,7 +3415,7 @@
 			<push arg="73"/>
 			<pcall arg="326"/>
 			<dup/>
-			<push arg="742"/>
+			<push arg="735"/>
 			<load arg="19"/>
 			<pcall arg="328"/>
 			<dup/>
@@ -3434,30 +3435,30 @@
 			<enditerate/>
 		</code>
 		<linenumbertable>
-			<lne id="743" begin="7" end="7"/>
-			<lne id="744" begin="7" end="8"/>
-			<lne id="745" begin="9" end="11"/>
-			<lne id="746" begin="7" end="12"/>
-			<lne id="747" begin="13" end="13"/>
-			<lne id="748" begin="13" end="14"/>
-			<lne id="749" begin="13" end="15"/>
-			<lne id="750" begin="7" end="16"/>
-			<lne id="751" begin="31" end="36"/>
-			<lne id="752" begin="37" end="42"/>
+			<lne id="736" begin="7" end="7"/>
+			<lne id="737" begin="7" end="8"/>
+			<lne id="738" begin="9" end="11"/>
+			<lne id="739" begin="7" end="12"/>
+			<lne id="740" begin="13" end="13"/>
+			<lne id="741" begin="13" end="14"/>
+			<lne id="742" begin="13" end="15"/>
+			<lne id="743" begin="7" end="16"/>
+			<lne id="744" begin="31" end="36"/>
+			<lne id="745" begin="37" end="42"/>
 		</linenumbertable>
 		<localvariabletable>
-			<lve slot="1" name="742" begin="6" end="44"/>
+			<lve slot="1" name="735" begin="6" end="44"/>
 			<lve slot="0" name="17" begin="0" end="45"/>
 		</localvariabletable>
 	</operation>
-	<operation name="753">
+	<operation name="746">
 		<context type="6"/>
 		<parameters>
 			<parameter name="19" type="336"/>
 		</parameters>
 		<code>
 			<load arg="19"/>
-			<push arg="742"/>
+			<push arg="735"/>
 			<call arg="337"/>
 			<store arg="29"/>
 			<load arg="19"/>
@@ -3472,7 +3473,7 @@
 			<dup/>
 			<getasm/>
 			<load arg="29"/>
-			<get arg="738"/>
+			<get arg="731"/>
 			<get arg="38"/>
 			<call arg="30"/>
 			<set arg="543"/>
@@ -3492,32 +3493,32 @@
 			<pop/>
 		</code>
 		<linenumbertable>
-			<lne id="754" begin="15" end="15"/>
-			<lne id="755" begin="15" end="16"/>
-			<lne id="756" begin="15" end="17"/>
-			<lne id="757" begin="13" end="19"/>
-			<lne id="758" begin="22" end="22"/>
-			<lne id="759" begin="20" end="24"/>
-			<lne id="751" begin="12" end="25"/>
-			<lne id="760" begin="29" end="29"/>
-			<lne id="761" begin="29" end="30"/>
-			<lne id="762" begin="27" end="32"/>
-			<lne id="752" begin="26" end="33"/>
+			<lne id="747" begin="15" end="15"/>
+			<lne id="748" begin="15" end="16"/>
+			<lne id="749" begin="15" end="17"/>
+			<lne id="750" begin="13" end="19"/>
+			<lne id="751" begin="22" end="22"/>
+			<lne id="752" begin="20" end="24"/>
+			<lne id="744" begin="12" end="25"/>
+			<lne id="753" begin="29" end="29"/>
+			<lne id="754" begin="29" end="30"/>
+			<lne id="755" begin="27" end="32"/>
+			<lne id="745" begin="26" end="33"/>
 		</linenumbertable>
 		<localvariabletable>
 			<lve slot="3" name="623" begin="7" end="33"/>
 			<lve slot="4" name="625" begin="11" end="33"/>
-			<lve slot="2" name="742" begin="3" end="33"/>
+			<lve slot="2" name="735" begin="3" end="33"/>
 			<lve slot="0" name="17" begin="0" end="33"/>
 			<lve slot="1" name="463" begin="0" end="33"/>
 		</localvariabletable>
 	</operation>
-	<operation name="763">
+	<operation name="756">
 		<context type="6"/>
 		<parameters>
 		</parameters>
 		<code>
-			<push arg="737"/>
+			<push arg="730"/>
 			<push arg="91"/>
 			<findme/>
 			<push arg="323"/>
@@ -3525,16 +3526,16 @@
 			<iterate/>
 			<store arg="19"/>
 			<load arg="19"/>
-			<get arg="738"/>
-			<push arg="739"/>
+			<get arg="731"/>
+			<push arg="732"/>
 			<push arg="91"/>
 			<findme/>
 			<call arg="98"/>
 			<load arg="19"/>
-			<call arg="740"/>
-			<call arg="717"/>
+			<call arg="733"/>
+			<call arg="713"/>
 			<call arg="155"/>
-			<if arg="764"/>
+			<if arg="757"/>
 			<getasm/>
 			<get arg="1"/>
 			<push arg="325"/>
@@ -3544,7 +3545,7 @@
 			<push arg="75"/>
 			<pcall arg="326"/>
 			<dup/>
-			<push arg="742"/>
+			<push arg="735"/>
 			<load arg="19"/>
 			<pcall arg="328"/>
 			<dup/>
@@ -3560,7 +3561,7 @@
 			<new/>
 			<pcall arg="332"/>
 			<dup/>
-			<push arg="765"/>
+			<push arg="758"/>
 			<push arg="505"/>
 			<push arg="331"/>
 			<new/>
@@ -3570,30 +3571,30 @@
 			<enditerate/>
 		</code>
 		<linenumbertable>
-			<lne id="766" begin="7" end="7"/>
-			<lne id="767" begin="7" end="8"/>
-			<lne id="768" begin="9" end="11"/>
-			<lne id="769" begin="7" end="12"/>
-			<lne id="770" begin="13" end="13"/>
-			<lne id="771" begin="13" end="14"/>
-			<lne id="772" begin="7" end="15"/>
-			<lne id="773" begin="30" end="35"/>
-			<lne id="774" begin="36" end="41"/>
-			<lne id="775" begin="42" end="47"/>
+			<lne id="759" begin="7" end="7"/>
+			<lne id="760" begin="7" end="8"/>
+			<lne id="761" begin="9" end="11"/>
+			<lne id="762" begin="7" end="12"/>
+			<lne id="763" begin="13" end="13"/>
+			<lne id="764" begin="13" end="14"/>
+			<lne id="765" begin="7" end="15"/>
+			<lne id="766" begin="30" end="35"/>
+			<lne id="767" begin="36" end="41"/>
+			<lne id="768" begin="42" end="47"/>
 		</linenumbertable>
 		<localvariabletable>
-			<lve slot="1" name="742" begin="6" end="49"/>
+			<lve slot="1" name="735" begin="6" end="49"/>
 			<lve slot="0" name="17" begin="0" end="50"/>
 		</localvariabletable>
 	</operation>
-	<operation name="776">
+	<operation name="769">
 		<context type="6"/>
 		<parameters>
 			<parameter name="19" type="336"/>
 		</parameters>
 		<code>
 			<load arg="19"/>
-			<push arg="742"/>
+			<push arg="735"/>
 			<call arg="337"/>
 			<store arg="29"/>
 			<load arg="19"/>
@@ -3605,14 +3606,14 @@
 			<call arg="338"/>
 			<store arg="342"/>
 			<load arg="19"/>
-			<push arg="765"/>
+			<push arg="758"/>
 			<call arg="338"/>
 			<store arg="349"/>
 			<load arg="203"/>
 			<dup/>
 			<getasm/>
 			<load arg="29"/>
-			<get arg="738"/>
+			<get arg="731"/>
 			<get arg="38"/>
 			<call arg="30"/>
 			<set arg="543"/>
@@ -3639,36 +3640,36 @@
 			<pop/>
 		</code>
 		<linenumbertable>
-			<lne id="777" begin="19" end="19"/>
-			<lne id="778" begin="19" end="20"/>
-			<lne id="779" begin="19" end="21"/>
-			<lne id="780" begin="17" end="23"/>
-			<lne id="781" begin="26" end="26"/>
-			<lne id="782" begin="24" end="28"/>
-			<lne id="773" begin="16" end="29"/>
-			<lne id="783" begin="33" end="33"/>
-			<lne id="784" begin="31" end="35"/>
-			<lne id="774" begin="30" end="36"/>
-			<lne id="785" begin="40" end="40"/>
-			<lne id="786" begin="40" end="41"/>
-			<lne id="787" begin="38" end="43"/>
-			<lne id="775" begin="37" end="44"/>
+			<lne id="770" begin="19" end="19"/>
+			<lne id="771" begin="19" end="20"/>
+			<lne id="772" begin="19" end="21"/>
+			<lne id="773" begin="17" end="23"/>
+			<lne id="774" begin="26" end="26"/>
+			<lne id="775" begin="24" end="28"/>
+			<lne id="766" begin="16" end="29"/>
+			<lne id="776" begin="33" end="33"/>
+			<lne id="777" begin="31" end="35"/>
+			<lne id="767" begin="30" end="36"/>
+			<lne id="778" begin="40" end="40"/>
+			<lne id="779" begin="40" end="41"/>
+			<lne id="780" begin="38" end="43"/>
+			<lne id="768" begin="37" end="44"/>
 		</linenumbertable>
 		<localvariabletable>
 			<lve slot="3" name="623" begin="7" end="44"/>
 			<lve slot="4" name="625" begin="11" end="44"/>
-			<lve slot="5" name="765" begin="15" end="44"/>
-			<lve slot="2" name="742" begin="3" end="44"/>
+			<lve slot="5" name="758" begin="15" end="44"/>
+			<lve slot="2" name="735" begin="3" end="44"/>
 			<lve slot="0" name="17" begin="0" end="44"/>
 			<lve slot="1" name="463" begin="0" end="44"/>
 		</localvariabletable>
 	</operation>
-	<operation name="788">
+	<operation name="781">
 		<context type="6"/>
 		<parameters>
 		</parameters>
 		<code>
-			<push arg="737"/>
+			<push arg="730"/>
 			<push arg="91"/>
 			<findme/>
 			<push arg="323"/>
@@ -3676,15 +3677,15 @@
 			<iterate/>
 			<store arg="19"/>
 			<load arg="19"/>
-			<get arg="738"/>
-			<push arg="789"/>
+			<get arg="731"/>
+			<push arg="782"/>
 			<push arg="91"/>
 			<findme/>
 			<call arg="98"/>
 			<load arg="19"/>
-			<call arg="740"/>
+			<call arg="733"/>
 			<call arg="555"/>
-			<call arg="717"/>
+			<call arg="713"/>
 			<call arg="155"/>
 			<if arg="530"/>
 			<getasm/>
@@ -3696,12 +3697,12 @@
 			<push arg="77"/>
 			<pcall arg="326"/>
 			<dup/>
-			<push arg="742"/>
+			<push arg="735"/>
 			<load arg="19"/>
 			<pcall arg="328"/>
 			<dup/>
-			<push arg="790"/>
-			<push arg="791"/>
+			<push arg="783"/>
+			<push arg="784"/>
 			<push arg="331"/>
 			<new/>
 			<pcall arg="332"/>
@@ -3710,40 +3711,40 @@
 			<enditerate/>
 		</code>
 		<linenumbertable>
-			<lne id="792" begin="7" end="7"/>
-			<lne id="793" begin="7" end="8"/>
-			<lne id="794" begin="9" end="11"/>
-			<lne id="795" begin="7" end="12"/>
-			<lne id="796" begin="13" end="13"/>
-			<lne id="797" begin="13" end="14"/>
-			<lne id="798" begin="13" end="15"/>
-			<lne id="799" begin="7" end="16"/>
-			<lne id="800" begin="31" end="36"/>
+			<lne id="785" begin="7" end="7"/>
+			<lne id="786" begin="7" end="8"/>
+			<lne id="787" begin="9" end="11"/>
+			<lne id="788" begin="7" end="12"/>
+			<lne id="789" begin="13" end="13"/>
+			<lne id="790" begin="13" end="14"/>
+			<lne id="791" begin="13" end="15"/>
+			<lne id="792" begin="7" end="16"/>
+			<lne id="793" begin="31" end="36"/>
 		</linenumbertable>
 		<localvariabletable>
-			<lve slot="1" name="742" begin="6" end="38"/>
+			<lve slot="1" name="735" begin="6" end="38"/>
 			<lve slot="0" name="17" begin="0" end="39"/>
 		</localvariabletable>
 	</operation>
-	<operation name="801">
+	<operation name="794">
 		<context type="6"/>
 		<parameters>
 			<parameter name="19" type="336"/>
 		</parameters>
 		<code>
 			<load arg="19"/>
-			<push arg="742"/>
+			<push arg="735"/>
 			<call arg="337"/>
 			<store arg="29"/>
 			<load arg="19"/>
-			<push arg="790"/>
+			<push arg="783"/>
 			<call arg="338"/>
 			<store arg="203"/>
 			<load arg="203"/>
 			<dup/>
 			<getasm/>
 			<load arg="29"/>
-			<get arg="738"/>
+			<get arg="731"/>
 			<get arg="38"/>
 			<call arg="30"/>
 			<set arg="38"/>
@@ -3756,28 +3757,28 @@
 			<pop/>
 		</code>
 		<linenumbertable>
-			<lne id="802" begin="11" end="11"/>
-			<lne id="803" begin="11" end="12"/>
-			<lne id="804" begin="11" end="13"/>
-			<lne id="805" begin="9" end="15"/>
-			<lne id="806" begin="18" end="18"/>
-			<lne id="807" begin="18" end="19"/>
-			<lne id="808" begin="16" end="21"/>
-			<lne id="800" begin="8" end="22"/>
+			<lne id="795" begin="11" end="11"/>
+			<lne id="796" begin="11" end="12"/>
+			<lne id="797" begin="11" end="13"/>
+			<lne id="798" begin="9" end="15"/>
+			<lne id="799" begin="18" end="18"/>
+			<lne id="800" begin="18" end="19"/>
+			<lne id="801" begin="16" end="21"/>
+			<lne id="793" begin="8" end="22"/>
 		</linenumbertable>
 		<localvariabletable>
-			<lve slot="3" name="790" begin="7" end="22"/>
-			<lve slot="2" name="742" begin="3" end="22"/>
+			<lve slot="3" name="783" begin="7" end="22"/>
+			<lve slot="2" name="735" begin="3" end="22"/>
 			<lve slot="0" name="17" begin="0" end="22"/>
 			<lve slot="1" name="463" begin="0" end="22"/>
 		</localvariabletable>
 	</operation>
-	<operation name="809">
+	<operation name="802">
 		<context type="6"/>
 		<parameters>
 		</parameters>
 		<code>
-			<push arg="737"/>
+			<push arg="730"/>
 			<push arg="91"/>
 			<findme/>
 			<push arg="323"/>
@@ -3785,25 +3786,25 @@
 			<iterate/>
 			<store arg="19"/>
 			<load arg="19"/>
-			<get arg="738"/>
-			<push arg="789"/>
+			<get arg="731"/>
+			<push arg="782"/>
 			<push arg="91"/>
 			<findme/>
 			<call arg="98"/>
 			<load arg="19"/>
-			<call arg="740"/>
-			<call arg="717"/>
+			<call arg="733"/>
+			<call arg="713"/>
 			<load arg="19"/>
-			<get arg="738"/>
-			<get arg="810"/>
-			<push arg="811"/>
+			<get arg="731"/>
+			<get arg="803"/>
+			<push arg="804"/>
 			<push arg="91"/>
 			<findme/>
 			<call arg="92"/>
 			<call arg="555"/>
-			<call arg="717"/>
+			<call arg="713"/>
 			<call arg="155"/>
-			<if arg="812"/>
+			<if arg="805"/>
 			<getasm/>
 			<get arg="1"/>
 			<push arg="325"/>
@@ -3813,17 +3814,17 @@
 			<push arg="79"/>
 			<pcall arg="326"/>
 			<dup/>
-			<push arg="742"/>
+			<push arg="735"/>
 			<load arg="19"/>
 			<pcall arg="328"/>
 			<dup/>
-			<push arg="790"/>
-			<push arg="791"/>
+			<push arg="783"/>
+			<push arg="784"/>
 			<push arg="331"/>
 			<new/>
 			<pcall arg="332"/>
 			<dup/>
-			<push arg="765"/>
+			<push arg="758"/>
 			<push arg="505"/>
 			<push arg="331"/>
 			<new/>
@@ -3833,51 +3834,51 @@
 			<enditerate/>
 		</code>
 		<linenumbertable>
-			<lne id="813" begin="7" end="7"/>
-			<lne id="814" begin="7" end="8"/>
-			<lne id="815" begin="9" end="11"/>
-			<lne id="816" begin="7" end="12"/>
-			<lne id="817" begin="13" end="13"/>
-			<lne id="818" begin="13" end="14"/>
-			<lne id="819" begin="7" end="15"/>
-			<lne id="820" begin="16" end="16"/>
-			<lne id="821" begin="16" end="17"/>
-			<lne id="822" begin="16" end="18"/>
-			<lne id="823" begin="19" end="21"/>
-			<lne id="824" begin="16" end="22"/>
-			<lne id="825" begin="16" end="23"/>
-			<lne id="826" begin="7" end="24"/>
-			<lne id="827" begin="39" end="44"/>
-			<lne id="828" begin="45" end="50"/>
+			<lne id="806" begin="7" end="7"/>
+			<lne id="807" begin="7" end="8"/>
+			<lne id="808" begin="9" end="11"/>
+			<lne id="809" begin="7" end="12"/>
+			<lne id="810" begin="13" end="13"/>
+			<lne id="811" begin="13" end="14"/>
+			<lne id="812" begin="7" end="15"/>
+			<lne id="813" begin="16" end="16"/>
+			<lne id="814" begin="16" end="17"/>
+			<lne id="815" begin="16" end="18"/>
+			<lne id="816" begin="19" end="21"/>
+			<lne id="817" begin="16" end="22"/>
+			<lne id="818" begin="16" end="23"/>
+			<lne id="819" begin="7" end="24"/>
+			<lne id="820" begin="39" end="44"/>
+			<lne id="821" begin="45" end="50"/>
 		</linenumbertable>
 		<localvariabletable>
-			<lve slot="1" name="742" begin="6" end="52"/>
+			<lve slot="1" name="735" begin="6" end="52"/>
 			<lve slot="0" name="17" begin="0" end="53"/>
 		</localvariabletable>
 	</operation>
-	<operation name="829">
+	<operation name="822">
 		<context type="6"/>
 		<parameters>
 			<parameter name="19" type="336"/>
 		</parameters>
 		<code>
 			<load arg="19"/>
-			<push arg="742"/>
+			<push arg="735"/>
 			<call arg="337"/>
 			<store arg="29"/>
 			<load arg="19"/>
-			<push arg="790"/>
+			<push arg="783"/>
 			<call arg="338"/>
 			<store arg="203"/>
 			<load arg="19"/>
-			<push arg="765"/>
+			<push arg="758"/>
 			<call arg="338"/>
 			<store arg="342"/>
 			<load arg="203"/>
 			<dup/>
 			<getasm/>
 			<load arg="29"/>
-			<get arg="738"/>
+			<get arg="731"/>
 			<get arg="38"/>
 			<call arg="30"/>
 			<set arg="38"/>
@@ -3897,32 +3898,32 @@
 			<pop/>
 		</code>
 		<linenumbertable>
-			<lne id="830" begin="15" end="15"/>
-			<lne id="831" begin="15" end="16"/>
-			<lne id="832" begin="15" end="17"/>
-			<lne id="833" begin="13" end="19"/>
-			<lne id="834" begin="22" end="22"/>
-			<lne id="835" begin="20" end="24"/>
-			<lne id="827" begin="12" end="25"/>
-			<lne id="836" begin="29" end="29"/>
-			<lne id="837" begin="29" end="30"/>
-			<lne id="838" begin="27" end="32"/>
-			<lne id="828" begin="26" end="33"/>
+			<lne id="823" begin="15" end="15"/>
+			<lne id="824" begin="15" end="16"/>
+			<lne id="825" begin="15" end="17"/>
+			<lne id="826" begin="13" end="19"/>
+			<lne id="827" begin="22" end="22"/>
+			<lne id="828" begin="20" end="24"/>
+			<lne id="820" begin="12" end="25"/>
+			<lne id="829" begin="29" end="29"/>
+			<lne id="830" begin="29" end="30"/>
+			<lne id="831" begin="27" end="32"/>
+			<lne id="821" begin="26" end="33"/>
 		</linenumbertable>
 		<localvariabletable>
-			<lve slot="3" name="790" begin="7" end="33"/>
-			<lve slot="4" name="765" begin="11" end="33"/>
-			<lve slot="2" name="742" begin="3" end="33"/>
+			<lve slot="3" name="783" begin="7" end="33"/>
+			<lve slot="4" name="758" begin="11" end="33"/>
+			<lve slot="2" name="735" begin="3" end="33"/>
 			<lve slot="0" name="17" begin="0" end="33"/>
 			<lve slot="1" name="463" begin="0" end="33"/>
 		</localvariabletable>
 	</operation>
-	<operation name="839">
+	<operation name="832">
 		<context type="6"/>
 		<parameters>
 		</parameters>
 		<code>
-			<push arg="737"/>
+			<push arg="730"/>
 			<push arg="91"/>
 			<findme/>
 			<push arg="323"/>
@@ -3930,31 +3931,38 @@
 			<iterate/>
 			<store arg="19"/>
 			<load arg="19"/>
-			<get arg="738"/>
-			<push arg="789"/>
+			<get arg="731"/>
+			<push arg="782"/>
 			<push arg="91"/>
 			<findme/>
 			<call arg="92"/>
 			<load arg="19"/>
-			<get arg="738"/>
-			<get arg="810"/>
-			<push arg="811"/>
+			<get arg="731"/>
+			<get arg="803"/>
+			<push arg="804"/>
 			<push arg="91"/>
 			<findme/>
 			<call arg="92"/>
-			<call arg="717"/>
+			<call arg="713"/>
 			<load arg="19"/>
-			<get arg="738"/>
-			<get arg="810"/>
-			<get arg="840"/>
-			<push arg="841"/>
+			<get arg="731"/>
+			<get arg="803"/>
+			<get arg="833"/>
+			<push arg="834"/>
 			<call arg="158"/>
-			<call arg="717"/>
 			<load arg="19"/>
-			<call arg="740"/>
-			<call arg="717"/>
+			<get arg="731"/>
+			<get arg="803"/>
+			<get arg="833"/>
+			<push arg="835"/>
+			<call arg="158"/>
+			<call arg="94"/>
+			<call arg="713"/>
+			<load arg="19"/>
+			<call arg="733"/>
+			<call arg="713"/>
 			<call arg="155"/>
-			<if arg="842"/>
+			<if arg="836"/>
 			<getasm/>
 			<get arg="1"/>
 			<push arg="325"/>
@@ -3964,23 +3972,23 @@
 			<push arg="81"/>
 			<pcall arg="326"/>
 			<dup/>
-			<push arg="742"/>
+			<push arg="735"/>
 			<load arg="19"/>
 			<pcall arg="328"/>
 			<dup/>
-			<push arg="790"/>
-			<push arg="791"/>
+			<push arg="783"/>
+			<push arg="784"/>
 			<push arg="331"/>
 			<new/>
 			<pcall arg="332"/>
 			<dup/>
-			<push arg="843"/>
+			<push arg="837"/>
 			<push arg="616"/>
 			<push arg="331"/>
 			<new/>
 			<pcall arg="332"/>
 			<dup/>
-			<push arg="844"/>
+			<push arg="838"/>
 			<push arg="619"/>
 			<push arg="331"/>
 			<new/>
@@ -3992,19 +4000,19 @@
 			<new/>
 			<pcall arg="332"/>
 			<dup/>
-			<push arg="845"/>
+			<push arg="839"/>
 			<push arg="604"/>
 			<push arg="331"/>
 			<new/>
 			<pcall arg="332"/>
 			<dup/>
-			<push arg="846"/>
-			<push arg="847"/>
+			<push arg="835"/>
+			<push arg="840"/>
 			<push arg="331"/>
 			<new/>
 			<pcall arg="332"/>
 			<dup/>
-			<push arg="848"/>
+			<push arg="841"/>
 			<push arg="505"/>
 			<push arg="331"/>
 			<new/>
@@ -4014,37 +4022,44 @@
 			<enditerate/>
 		</code>
 		<linenumbertable>
-			<lne id="849" begin="7" end="7"/>
-			<lne id="850" begin="7" end="8"/>
-			<lne id="851" begin="9" end="11"/>
-			<lne id="852" begin="7" end="12"/>
-			<lne id="853" begin="13" end="13"/>
-			<lne id="854" begin="13" end="14"/>
-			<lne id="855" begin="13" end="15"/>
-			<lne id="856" begin="16" end="18"/>
-			<lne id="857" begin="13" end="19"/>
-			<lne id="858" begin="7" end="20"/>
-			<lne id="859" begin="21" end="21"/>
-			<lne id="860" begin="21" end="22"/>
-			<lne id="861" begin="21" end="23"/>
-			<lne id="862" begin="21" end="24"/>
-			<lne id="863" begin="25" end="25"/>
-			<lne id="864" begin="21" end="26"/>
-			<lne id="865" begin="7" end="27"/>
-			<lne id="866" begin="28" end="28"/>
-			<lne id="867" begin="28" end="29"/>
-			<lne id="868" begin="7" end="30"/>
-			<lne id="869" begin="45" end="50"/>
-			<lne id="870" begin="51" end="56"/>
-			<lne id="871" begin="57" end="62"/>
-			<lne id="872" begin="63" end="68"/>
-			<lne id="873" begin="69" end="74"/>
-			<lne id="874" begin="75" end="80"/>
-			<lne id="875" begin="81" end="86"/>
+			<lne id="842" begin="7" end="7"/>
+			<lne id="843" begin="7" end="8"/>
+			<lne id="844" begin="9" end="11"/>
+			<lne id="845" begin="7" end="12"/>
+			<lne id="846" begin="13" end="13"/>
+			<lne id="847" begin="13" end="14"/>
+			<lne id="848" begin="13" end="15"/>
+			<lne id="849" begin="16" end="18"/>
+			<lne id="850" begin="13" end="19"/>
+			<lne id="851" begin="7" end="20"/>
+			<lne id="852" begin="21" end="21"/>
+			<lne id="853" begin="21" end="22"/>
+			<lne id="854" begin="21" end="23"/>
+			<lne id="855" begin="21" end="24"/>
+			<lne id="856" begin="25" end="25"/>
+			<lne id="857" begin="21" end="26"/>
+			<lne id="858" begin="27" end="27"/>
+			<lne id="859" begin="27" end="28"/>
+			<lne id="860" begin="27" end="29"/>
+			<lne id="861" begin="27" end="30"/>
+			<lne id="862" begin="31" end="31"/>
+			<lne id="863" begin="27" end="32"/>
+			<lne id="864" begin="21" end="33"/>
+			<lne id="865" begin="7" end="34"/>
+			<lne id="866" begin="35" end="35"/>
+			<lne id="867" begin="35" end="36"/>
+			<lne id="868" begin="7" end="37"/>
+			<lne id="869" begin="52" end="57"/>
+			<lne id="870" begin="58" end="63"/>
+			<lne id="871" begin="64" end="69"/>
+			<lne id="872" begin="70" end="75"/>
+			<lne id="873" begin="76" end="81"/>
+			<lne id="874" begin="82" end="87"/>
+			<lne id="875" begin="88" end="93"/>
 		</linenumbertable>
 		<localvariabletable>
-			<lve slot="1" name="742" begin="6" end="88"/>
-			<lve slot="0" name="17" begin="0" end="89"/>
+			<lve slot="1" name="735" begin="6" end="95"/>
+			<lve slot="0" name="17" begin="0" end="96"/>
 		</localvariabletable>
 	</operation>
 	<operation name="876">
@@ -4054,19 +4069,19 @@
 		</parameters>
 		<code>
 			<load arg="19"/>
-			<push arg="742"/>
+			<push arg="735"/>
 			<call arg="337"/>
 			<store arg="29"/>
 			<load arg="19"/>
-			<push arg="790"/>
+			<push arg="783"/>
 			<call arg="338"/>
 			<store arg="203"/>
 			<load arg="19"/>
-			<push arg="843"/>
+			<push arg="837"/>
 			<call arg="338"/>
 			<store arg="342"/>
 			<load arg="19"/>
-			<push arg="844"/>
+			<push arg="838"/>
 			<call arg="338"/>
 			<store arg="349"/>
 			<load arg="19"/>
@@ -4074,22 +4089,22 @@
 			<call arg="338"/>
 			<store arg="641"/>
 			<load arg="19"/>
-			<push arg="845"/>
+			<push arg="839"/>
 			<call arg="338"/>
 			<store arg="642"/>
 			<load arg="19"/>
-			<push arg="846"/>
+			<push arg="835"/>
 			<call arg="338"/>
 			<store arg="643"/>
 			<load arg="19"/>
-			<push arg="848"/>
+			<push arg="841"/>
 			<call arg="338"/>
 			<store arg="215"/>
 			<load arg="203"/>
 			<dup/>
 			<getasm/>
 			<load arg="29"/>
-			<get arg="738"/>
+			<get arg="731"/>
 			<get arg="38"/>
 			<call arg="30"/>
 			<set arg="38"/>
@@ -4179,14 +4194,14 @@
 			<lne id="875" begin="86" end="93"/>
 		</linenumbertable>
 		<localvariabletable>
-			<lve slot="3" name="790" begin="7" end="93"/>
-			<lve slot="4" name="843" begin="11" end="93"/>
-			<lve slot="5" name="844" begin="15" end="93"/>
+			<lve slot="3" name="783" begin="7" end="93"/>
+			<lve slot="4" name="837" begin="11" end="93"/>
+			<lve slot="5" name="838" begin="15" end="93"/>
 			<lve slot="6" name="620" begin="19" end="93"/>
-			<lve slot="7" name="845" begin="23" end="93"/>
-			<lve slot="8" name="846" begin="27" end="93"/>
-			<lve slot="9" name="848" begin="31" end="93"/>
-			<lve slot="2" name="742" begin="3" end="93"/>
+			<lve slot="7" name="839" begin="23" end="93"/>
+			<lve slot="8" name="835" begin="27" end="93"/>
+			<lve slot="9" name="841" begin="31" end="93"/>
+			<lve slot="2" name="735" begin="3" end="93"/>
 			<lve slot="0" name="17" begin="0" end="93"/>
 			<lve slot="1" name="463" begin="0" end="93"/>
 		</localvariabletable>
@@ -4196,7 +4211,7 @@
 		<parameters>
 		</parameters>
 		<code>
-			<push arg="737"/>
+			<push arg="730"/>
 			<push arg="91"/>
 			<findme/>
 			<push arg="323"/>
@@ -4204,31 +4219,38 @@
 			<iterate/>
 			<store arg="19"/>
 			<load arg="19"/>
-			<get arg="738"/>
-			<push arg="789"/>
+			<get arg="731"/>
+			<push arg="782"/>
 			<push arg="91"/>
 			<findme/>
 			<call arg="92"/>
 			<load arg="19"/>
-			<get arg="738"/>
-			<get arg="810"/>
-			<push arg="811"/>
+			<get arg="731"/>
+			<get arg="803"/>
+			<push arg="804"/>
 			<push arg="91"/>
 			<findme/>
 			<call arg="92"/>
-			<call arg="717"/>
+			<call arg="713"/>
 			<load arg="19"/>
-			<get arg="738"/>
-			<get arg="810"/>
-			<get arg="840"/>
+			<get arg="731"/>
+			<get arg="803"/>
+			<get arg="833"/>
 			<push arg="900"/>
 			<call arg="158"/>
-			<call arg="717"/>
 			<load arg="19"/>
-			<call arg="740"/>
-			<call arg="717"/>
+			<get arg="731"/>
+			<get arg="803"/>
+			<get arg="833"/>
+			<push arg="901"/>
+			<call arg="158"/>
+			<call arg="94"/>
+			<call arg="713"/>
+			<load arg="19"/>
+			<call arg="733"/>
+			<call arg="713"/>
 			<call arg="155"/>
-			<if arg="812"/>
+			<if arg="902"/>
 			<getasm/>
 			<get arg="1"/>
 			<push arg="325"/>
@@ -4238,12 +4260,12 @@
 			<push arg="83"/>
 			<pcall arg="326"/>
 			<dup/>
-			<push arg="742"/>
+			<push arg="735"/>
 			<load arg="19"/>
 			<pcall arg="328"/>
 			<dup/>
-			<push arg="790"/>
-			<push arg="791"/>
+			<push arg="783"/>
+			<push arg="784"/>
 			<push arg="331"/>
 			<new/>
 			<pcall arg="332"/>
@@ -4252,77 +4274,84 @@
 			<enditerate/>
 		</code>
 		<linenumbertable>
-			<lne id="901" begin="7" end="7"/>
-			<lne id="902" begin="7" end="8"/>
-			<lne id="903" begin="9" end="11"/>
-			<lne id="904" begin="7" end="12"/>
-			<lne id="905" begin="13" end="13"/>
-			<lne id="906" begin="13" end="14"/>
-			<lne id="907" begin="13" end="15"/>
-			<lne id="908" begin="16" end="18"/>
-			<lne id="909" begin="13" end="19"/>
-			<lne id="910" begin="7" end="20"/>
-			<lne id="911" begin="21" end="21"/>
-			<lne id="912" begin="21" end="22"/>
-			<lne id="913" begin="21" end="23"/>
-			<lne id="914" begin="21" end="24"/>
-			<lne id="915" begin="25" end="25"/>
-			<lne id="916" begin="21" end="26"/>
-			<lne id="917" begin="7" end="27"/>
-			<lne id="918" begin="28" end="28"/>
-			<lne id="919" begin="28" end="29"/>
-			<lne id="920" begin="7" end="30"/>
-			<lne id="921" begin="45" end="50"/>
+			<lne id="903" begin="7" end="7"/>
+			<lne id="904" begin="7" end="8"/>
+			<lne id="905" begin="9" end="11"/>
+			<lne id="906" begin="7" end="12"/>
+			<lne id="907" begin="13" end="13"/>
+			<lne id="908" begin="13" end="14"/>
+			<lne id="909" begin="13" end="15"/>
+			<lne id="910" begin="16" end="18"/>
+			<lne id="911" begin="13" end="19"/>
+			<lne id="912" begin="7" end="20"/>
+			<lne id="913" begin="21" end="21"/>
+			<lne id="914" begin="21" end="22"/>
+			<lne id="915" begin="21" end="23"/>
+			<lne id="916" begin="21" end="24"/>
+			<lne id="917" begin="25" end="25"/>
+			<lne id="918" begin="21" end="26"/>
+			<lne id="919" begin="27" end="27"/>
+			<lne id="920" begin="27" end="28"/>
+			<lne id="921" begin="27" end="29"/>
+			<lne id="922" begin="27" end="30"/>
+			<lne id="923" begin="31" end="31"/>
+			<lne id="924" begin="27" end="32"/>
+			<lne id="925" begin="21" end="33"/>
+			<lne id="926" begin="7" end="34"/>
+			<lne id="927" begin="35" end="35"/>
+			<lne id="928" begin="35" end="36"/>
+			<lne id="929" begin="7" end="37"/>
+			<lne id="930" begin="52" end="57"/>
 		</linenumbertable>
 		<localvariabletable>
-			<lve slot="1" name="742" begin="6" end="52"/>
-			<lve slot="0" name="17" begin="0" end="53"/>
+			<lve slot="1" name="735" begin="6" end="59"/>
+			<lve slot="0" name="17" begin="0" end="60"/>
 		</localvariabletable>
 	</operation>
-	<operation name="922">
+	<operation name="931">
 		<context type="6"/>
 		<parameters>
 			<parameter name="19" type="336"/>
 		</parameters>
 		<code>
 			<load arg="19"/>
-			<push arg="742"/>
+			<push arg="735"/>
 			<call arg="337"/>
 			<store arg="29"/>
 			<load arg="19"/>
-			<push arg="790"/>
+			<push arg="783"/>
 			<call arg="338"/>
 			<store arg="203"/>
 			<load arg="203"/>
 			<dup/>
 			<getasm/>
 			<load arg="29"/>
-			<get arg="738"/>
+			<get arg="731"/>
 			<get arg="38"/>
 			<call arg="30"/>
 			<set arg="38"/>
 			<pop/>
 		</code>
 		<linenumbertable>
-			<lne id="923" begin="11" end="11"/>
-			<lne id="924" begin="11" end="12"/>
-			<lne id="925" begin="11" end="13"/>
-			<lne id="926" begin="9" end="15"/>
-			<lne id="921" begin="8" end="16"/>
+			<lne id="932" begin="11" end="11"/>
+			<lne id="933" begin="11" end="12"/>
+			<lne id="934" begin="11" end="13"/>
+			<lne id="935" begin="9" end="15"/>
+			<lne id="930" begin="8" end="16"/>
 		</linenumbertable>
 		<localvariabletable>
-			<lve slot="3" name="790" begin="7" end="16"/>
-			<lve slot="2" name="742" begin="3" end="16"/>
+			<lve slot="3" name="783" begin="7" end="16"/>
+			<lve slot="2" name="735" begin="3" end="16"/>
 			<lve slot="0" name="17" begin="0" end="16"/>
 			<lve slot="1" name="463" begin="0" end="16"/>
 		</localvariabletable>
 	</operation>
-	<operation name="927">
+	<operation name="936">
 		<context type="6"/>
 		<parameters>
 		</parameters>
 		<code>
-			<push arg="737"/>
+			<push arg="730"/>
 			<push arg="91"/>
 			<findme/>
 			<push arg="323"/>
@@ -4330,31 +4359,31 @@
 			<iterate/>
 			<store arg="19"/>
 			<load arg="19"/>
-			<get arg="738"/>
-			<push arg="789"/>
+			<get arg="731"/>
+			<push arg="782"/>
 			<push arg="91"/>
 			<findme/>
 			<call arg="92"/>
 			<load arg="19"/>
-			<get arg="738"/>
-			<get arg="810"/>
-			<push arg="811"/>
+			<get arg="731"/>
+			<get arg="803"/>
+			<push arg="804"/>
 			<push arg="91"/>
 			<findme/>
 			<call arg="92"/>
-			<call arg="717"/>
+			<call arg="713"/>
 			<load arg="19"/>
-			<get arg="738"/>
-			<get arg="810"/>
-			<get arg="840"/>
-			<push arg="928"/>
+			<get arg="731"/>
+			<get arg="803"/>
+			<get arg="833"/>
+			<push arg="937"/>
 			<call arg="158"/>
-			<call arg="717"/>
+			<call arg="713"/>
 			<load arg="19"/>
-			<call arg="740"/>
-			<call arg="717"/>
+			<call arg="733"/>
+			<call arg="713"/>
 			<call arg="155"/>
-			<if arg="812"/>
+			<if arg="805"/>
 			<getasm/>
 			<get arg="1"/>
 			<push arg="325"/>
@@ -4364,12 +4393,12 @@
 			<push arg="85"/>
 			<pcall arg="326"/>
 			<dup/>
-			<push arg="742"/>
+			<push arg="735"/>
 			<load arg="19"/>
 			<pcall arg="328"/>
 			<dup/>
-			<push arg="790"/>
-			<push arg="791"/>
+			<push arg="783"/>
+			<push arg="784"/>
 			<push arg="331"/>
 			<new/>
 			<pcall arg="332"/>
@@ -4378,67 +4407,67 @@
 			<enditerate/>
 		</code>
 		<linenumbertable>
-			<lne id="929" begin="7" end="7"/>
-			<lne id="930" begin="7" end="8"/>
-			<lne id="931" begin="9" end="11"/>
-			<lne id="932" begin="7" end="12"/>
-			<lne id="933" begin="13" end="13"/>
-			<lne id="934" begin="13" end="14"/>
-			<lne id="935" begin="13" end="15"/>
-			<lne id="936" begin="16" end="18"/>
-			<lne id="937" begin="13" end="19"/>
-			<lne id="938" begin="7" end="20"/>
-			<lne id="939" begin="21" end="21"/>
-			<lne id="940" begin="21" end="22"/>
-			<lne id="941" begin="21" end="23"/>
-			<lne id="942" begin="21" end="24"/>
-			<lne id="943" begin="25" end="25"/>
-			<lne id="944" begin="21" end="26"/>
-			<lne id="945" begin="7" end="27"/>
-			<lne id="946" begin="28" end="28"/>
-			<lne id="947" begin="28" end="29"/>
-			<lne id="948" begin="7" end="30"/>
-			<lne id="949" begin="45" end="50"/>
+			<lne id="938" begin="7" end="7"/>
+			<lne id="939" begin="7" end="8"/>
+			<lne id="940" begin="9" end="11"/>
+			<lne id="941" begin="7" end="12"/>
+			<lne id="942" begin="13" end="13"/>
+			<lne id="943" begin="13" end="14"/>
+			<lne id="944" begin="13" end="15"/>
+			<lne id="945" begin="16" end="18"/>
+			<lne id="946" begin="13" end="19"/>
+			<lne id="947" begin="7" end="20"/>
+			<lne id="948" begin="21" end="21"/>
+			<lne id="949" begin="21" end="22"/>
+			<lne id="950" begin="21" end="23"/>
+			<lne id="951" begin="21" end="24"/>
+			<lne id="952" begin="25" end="25"/>
+			<lne id="953" begin="21" end="26"/>
+			<lne id="954" begin="7" end="27"/>
+			<lne id="955" begin="28" end="28"/>
+			<lne id="956" begin="28" end="29"/>
+			<lne id="957" begin="7" end="30"/>
+			<lne id="958" begin="45" end="50"/>
 		</linenumbertable>
 		<localvariabletable>
-			<lve slot="1" name="742" begin="6" end="52"/>
+			<lve slot="1" name="735" begin="6" end="52"/>
 			<lve slot="0" name="17" begin="0" end="53"/>
 		</localvariabletable>
 	</operation>
-	<operation name="950">
+	<operation name="959">
 		<context type="6"/>
 		<parameters>
 			<parameter name="19" type="336"/>
 		</parameters>
 		<code>
 			<load arg="19"/>
-			<push arg="742"/>
+			<push arg="735"/>
 			<call arg="337"/>
 			<store arg="29"/>
 			<load arg="19"/>
-			<push arg="790"/>
+			<push arg="783"/>
 			<call arg="338"/>
 			<store arg="203"/>
 			<load arg="203"/>
 			<dup/>
 			<getasm/>
 			<load arg="29"/>
-			<get arg="738"/>
+			<get arg="731"/>
 			<get arg="38"/>
 			<call arg="30"/>
 			<set arg="38"/>
 			<pop/>
 		</code>
 		<linenumbertable>
-			<lne id="951" begin="11" end="11"/>
-			<lne id="952" begin="11" end="12"/>
-			<lne id="953" begin="11" end="13"/>
-			<lne id="954" begin="9" end="15"/>
-			<lne id="949" begin="8" end="16"/>
+			<lne id="960" begin="11" end="11"/>
+			<lne id="961" begin="11" end="12"/>
+			<lne id="962" begin="11" end="13"/>
+			<lne id="963" begin="9" end="15"/>
+			<lne id="958" begin="8" end="16"/>
 		</linenumbertable>
 		<localvariabletable>
-			<lve slot="3" name="790" begin="7" end="16"/>
-			<lve slot="2" name="742" begin="3" end="16"/>
+			<lve slot="3" name="783" begin="7" end="16"/>
+			<lve slot="2" name="735" begin="3" end="16"/>
 			<lve slot="0" name="17" begin="0" end="16"/>
 			<lve slot="1" name="463" begin="0" end="16"/>
 		</localvariabletable>

--- a/transformation/src/fr/inria/atlanmod/mogwai/transformation/files/ocl2gremlin.asm
+++ b/transformation/src/fr/inria/atlanmod/mogwai/transformation/files/ocl2gremlin.asm
@@ -841,7 +841,8 @@
 		<constant value="398:19-398:38"/>
 		<constant value="398:4-398:38"/>
 		<constant value="__matchpropertyAttBooleanLastInComparison2steps"/>
-		<constant value="EBoolean"/>
+		<constant value="instanceClassName"/>
+		<constant value="java.lang.Boolean"/>
 		<constant value="89"/>
 		<constant value="transform"/>
 		<constant value="clos"/>
@@ -862,10 +863,10 @@
 		<constant value="407:4-407:8"/>
 		<constant value="407:4-407:25"/>
 		<constant value="407:4-407:31"/>
-		<constant value="407:4-407:36"/>
-		<constant value="407:39-407:49"/>
 		<constant value="407:4-407:49"/>
-		<constant value="405:4-407:49"/>
+		<constant value="407:52-407:71"/>
+		<constant value="407:4-407:71"/>
+		<constant value="405:4-407:71"/>
 		<constant value="408:4-408:8"/>
 		<constant value="408:4-408:29"/>
 		<constant value="405:4-408:29"/>
@@ -900,7 +901,7 @@
 		<constant value="433:19-433:38"/>
 		<constant value="433:4-433:38"/>
 		<constant value="__matchpropertyAttIntegerLastInComparison2steps"/>
-		<constant value="EInt"/>
+		<constant value="java.lang.Integer"/>
 		<constant value="440:4-440:8"/>
 		<constant value="440:4-440:25"/>
 		<constant value="440:38-440:52"/>
@@ -914,10 +915,10 @@
 		<constant value="442:4-442:8"/>
 		<constant value="442:4-442:25"/>
 		<constant value="442:4-442:31"/>
-		<constant value="442:4-442:36"/>
-		<constant value="442:39-442:45"/>
-		<constant value="442:4-442:45"/>
-		<constant value="440:4-442:45"/>
+		<constant value="442:4-442:49"/>
+		<constant value="442:52-442:71"/>
+		<constant value="442:4-442:71"/>
+		<constant value="440:4-442:71"/>
 		<constant value="443:4-443:8"/>
 		<constant value="443:4-443:29"/>
 		<constant value="440:4-443:29"/>
@@ -928,7 +929,7 @@
 		<constant value="447:12-447:38"/>
 		<constant value="447:4-447:38"/>
 		<constant value="__matchpropertyAttStringLastInComparison2steps"/>
-		<constant value="EString"/>
+		<constant value="java.lang.String"/>
 		<constant value="454:4-454:8"/>
 		<constant value="454:4-454:25"/>
 		<constant value="454:38-454:52"/>
@@ -942,10 +943,10 @@
 		<constant value="456:4-456:8"/>
 		<constant value="456:4-456:25"/>
 		<constant value="456:4-456:31"/>
-		<constant value="456:4-456:36"/>
-		<constant value="456:39-456:48"/>
-		<constant value="456:4-456:48"/>
-		<constant value="454:4-456:48"/>
+		<constant value="456:4-456:49"/>
+		<constant value="456:52-456:70"/>
+		<constant value="456:4-456:70"/>
+		<constant value="454:4-456:70"/>
 		<constant value="457:4-457:8"/>
 		<constant value="457:4-457:29"/>
 		<constant value="454:4-457:29"/>
@@ -3945,15 +3946,15 @@
 			<load arg="19"/>
 			<get arg="738"/>
 			<get arg="810"/>
-			<get arg="38"/>
-			<push arg="840"/>
+			<get arg="840"/>
+			<push arg="841"/>
 			<call arg="158"/>
 			<call arg="717"/>
 			<load arg="19"/>
 			<call arg="740"/>
 			<call arg="717"/>
 			<call arg="155"/>
-			<if arg="841"/>
+			<if arg="842"/>
 			<getasm/>
 			<get arg="1"/>
 			<push arg="325"/>
@@ -3973,13 +3974,13 @@
 			<new/>
 			<pcall arg="332"/>
 			<dup/>
-			<push arg="842"/>
+			<push arg="843"/>
 			<push arg="616"/>
 			<push arg="331"/>
 			<new/>
 			<pcall arg="332"/>
 			<dup/>
-			<push arg="843"/>
+			<push arg="844"/>
 			<push arg="619"/>
 			<push arg="331"/>
 			<new/>
@@ -3991,19 +3992,19 @@
 			<new/>
 			<pcall arg="332"/>
 			<dup/>
-			<push arg="844"/>
+			<push arg="845"/>
 			<push arg="604"/>
 			<push arg="331"/>
 			<new/>
 			<pcall arg="332"/>
 			<dup/>
-			<push arg="845"/>
 			<push arg="846"/>
+			<push arg="847"/>
 			<push arg="331"/>
 			<new/>
 			<pcall arg="332"/>
 			<dup/>
-			<push arg="847"/>
+			<push arg="848"/>
 			<push arg="505"/>
 			<push arg="331"/>
 			<new/>
@@ -4013,40 +4014,40 @@
 			<enditerate/>
 		</code>
 		<linenumbertable>
-			<lne id="848" begin="7" end="7"/>
-			<lne id="849" begin="7" end="8"/>
-			<lne id="850" begin="9" end="11"/>
-			<lne id="851" begin="7" end="12"/>
-			<lne id="852" begin="13" end="13"/>
-			<lne id="853" begin="13" end="14"/>
-			<lne id="854" begin="13" end="15"/>
-			<lne id="855" begin="16" end="18"/>
-			<lne id="856" begin="13" end="19"/>
-			<lne id="857" begin="7" end="20"/>
-			<lne id="858" begin="21" end="21"/>
-			<lne id="859" begin="21" end="22"/>
-			<lne id="860" begin="21" end="23"/>
-			<lne id="861" begin="21" end="24"/>
-			<lne id="862" begin="25" end="25"/>
-			<lne id="863" begin="21" end="26"/>
-			<lne id="864" begin="7" end="27"/>
-			<lne id="865" begin="28" end="28"/>
-			<lne id="866" begin="28" end="29"/>
-			<lne id="867" begin="7" end="30"/>
-			<lne id="868" begin="45" end="50"/>
-			<lne id="869" begin="51" end="56"/>
-			<lne id="870" begin="57" end="62"/>
-			<lne id="871" begin="63" end="68"/>
-			<lne id="872" begin="69" end="74"/>
-			<lne id="873" begin="75" end="80"/>
-			<lne id="874" begin="81" end="86"/>
+			<lne id="849" begin="7" end="7"/>
+			<lne id="850" begin="7" end="8"/>
+			<lne id="851" begin="9" end="11"/>
+			<lne id="852" begin="7" end="12"/>
+			<lne id="853" begin="13" end="13"/>
+			<lne id="854" begin="13" end="14"/>
+			<lne id="855" begin="13" end="15"/>
+			<lne id="856" begin="16" end="18"/>
+			<lne id="857" begin="13" end="19"/>
+			<lne id="858" begin="7" end="20"/>
+			<lne id="859" begin="21" end="21"/>
+			<lne id="860" begin="21" end="22"/>
+			<lne id="861" begin="21" end="23"/>
+			<lne id="862" begin="21" end="24"/>
+			<lne id="863" begin="25" end="25"/>
+			<lne id="864" begin="21" end="26"/>
+			<lne id="865" begin="7" end="27"/>
+			<lne id="866" begin="28" end="28"/>
+			<lne id="867" begin="28" end="29"/>
+			<lne id="868" begin="7" end="30"/>
+			<lne id="869" begin="45" end="50"/>
+			<lne id="870" begin="51" end="56"/>
+			<lne id="871" begin="57" end="62"/>
+			<lne id="872" begin="63" end="68"/>
+			<lne id="873" begin="69" end="74"/>
+			<lne id="874" begin="75" end="80"/>
+			<lne id="875" begin="81" end="86"/>
 		</linenumbertable>
 		<localvariabletable>
 			<lve slot="1" name="742" begin="6" end="88"/>
 			<lve slot="0" name="17" begin="0" end="89"/>
 		</localvariabletable>
 	</operation>
-	<operation name="875">
+	<operation name="876">
 		<context type="6"/>
 		<parameters>
 			<parameter name="19" type="336"/>
@@ -4061,11 +4062,11 @@
 			<call arg="338"/>
 			<store arg="203"/>
 			<load arg="19"/>
-			<push arg="842"/>
+			<push arg="843"/>
 			<call arg="338"/>
 			<store arg="342"/>
 			<load arg="19"/>
-			<push arg="843"/>
+			<push arg="844"/>
 			<call arg="338"/>
 			<store arg="349"/>
 			<load arg="19"/>
@@ -4073,15 +4074,15 @@
 			<call arg="338"/>
 			<store arg="641"/>
 			<load arg="19"/>
-			<push arg="844"/>
+			<push arg="845"/>
 			<call arg="338"/>
 			<store arg="642"/>
 			<load arg="19"/>
-			<push arg="845"/>
+			<push arg="846"/>
 			<call arg="338"/>
 			<store arg="643"/>
 			<load arg="19"/>
-			<push arg="847"/>
+			<push arg="848"/>
 			<call arg="338"/>
 			<store arg="215"/>
 			<load arg="203"/>
@@ -4134,7 +4135,7 @@
 			<load arg="643"/>
 			<dup/>
 			<getasm/>
-			<push arg="876"/>
+			<push arg="877"/>
 			<call arg="30"/>
 			<set arg="34"/>
 			<pop/>
@@ -4148,49 +4149,49 @@
 			<pop/>
 		</code>
 		<linenumbertable>
-			<lne id="877" begin="35" end="35"/>
-			<lne id="878" begin="35" end="36"/>
-			<lne id="879" begin="35" end="37"/>
-			<lne id="880" begin="33" end="39"/>
-			<lne id="881" begin="42" end="42"/>
-			<lne id="882" begin="40" end="44"/>
-			<lne id="868" begin="32" end="45"/>
-			<lne id="883" begin="49" end="49"/>
-			<lne id="884" begin="47" end="51"/>
-			<lne id="885" begin="54" end="54"/>
-			<lne id="886" begin="52" end="56"/>
-			<lne id="869" begin="46" end="57"/>
-			<lne id="887" begin="61" end="61"/>
-			<lne id="888" begin="59" end="63"/>
-			<lne id="870" begin="58" end="64"/>
-			<lne id="889" begin="68" end="68"/>
-			<lne id="890" begin="66" end="70"/>
-			<lne id="891" begin="73" end="73"/>
-			<lne id="892" begin="71" end="75"/>
-			<lne id="871" begin="65" end="76"/>
-			<lne id="872" begin="77" end="78"/>
-			<lne id="893" begin="82" end="82"/>
-			<lne id="894" begin="80" end="84"/>
-			<lne id="873" begin="79" end="85"/>
-			<lne id="895" begin="89" end="89"/>
-			<lne id="896" begin="89" end="90"/>
-			<lne id="897" begin="87" end="92"/>
-			<lne id="874" begin="86" end="93"/>
+			<lne id="878" begin="35" end="35"/>
+			<lne id="879" begin="35" end="36"/>
+			<lne id="880" begin="35" end="37"/>
+			<lne id="881" begin="33" end="39"/>
+			<lne id="882" begin="42" end="42"/>
+			<lne id="883" begin="40" end="44"/>
+			<lne id="869" begin="32" end="45"/>
+			<lne id="884" begin="49" end="49"/>
+			<lne id="885" begin="47" end="51"/>
+			<lne id="886" begin="54" end="54"/>
+			<lne id="887" begin="52" end="56"/>
+			<lne id="870" begin="46" end="57"/>
+			<lne id="888" begin="61" end="61"/>
+			<lne id="889" begin="59" end="63"/>
+			<lne id="871" begin="58" end="64"/>
+			<lne id="890" begin="68" end="68"/>
+			<lne id="891" begin="66" end="70"/>
+			<lne id="892" begin="73" end="73"/>
+			<lne id="893" begin="71" end="75"/>
+			<lne id="872" begin="65" end="76"/>
+			<lne id="873" begin="77" end="78"/>
+			<lne id="894" begin="82" end="82"/>
+			<lne id="895" begin="80" end="84"/>
+			<lne id="874" begin="79" end="85"/>
+			<lne id="896" begin="89" end="89"/>
+			<lne id="897" begin="89" end="90"/>
+			<lne id="898" begin="87" end="92"/>
+			<lne id="875" begin="86" end="93"/>
 		</linenumbertable>
 		<localvariabletable>
 			<lve slot="3" name="790" begin="7" end="93"/>
-			<lve slot="4" name="842" begin="11" end="93"/>
-			<lve slot="5" name="843" begin="15" end="93"/>
+			<lve slot="4" name="843" begin="11" end="93"/>
+			<lve slot="5" name="844" begin="15" end="93"/>
 			<lve slot="6" name="620" begin="19" end="93"/>
-			<lve slot="7" name="844" begin="23" end="93"/>
-			<lve slot="8" name="845" begin="27" end="93"/>
-			<lve slot="9" name="847" begin="31" end="93"/>
+			<lve slot="7" name="845" begin="23" end="93"/>
+			<lve slot="8" name="846" begin="27" end="93"/>
+			<lve slot="9" name="848" begin="31" end="93"/>
 			<lve slot="2" name="742" begin="3" end="93"/>
 			<lve slot="0" name="17" begin="0" end="93"/>
 			<lve slot="1" name="463" begin="0" end="93"/>
 		</localvariabletable>
 	</operation>
-	<operation name="898">
+	<operation name="899">
 		<context type="6"/>
 		<parameters>
 		</parameters>
@@ -4219,8 +4220,8 @@
 			<load arg="19"/>
 			<get arg="738"/>
 			<get arg="810"/>
-			<get arg="38"/>
-			<push arg="899"/>
+			<get arg="840"/>
+			<push arg="900"/>
 			<call arg="158"/>
 			<call arg="717"/>
 			<load arg="19"/>
@@ -4251,34 +4252,34 @@
 			<enditerate/>
 		</code>
 		<linenumbertable>
-			<lne id="900" begin="7" end="7"/>
-			<lne id="901" begin="7" end="8"/>
-			<lne id="902" begin="9" end="11"/>
-			<lne id="903" begin="7" end="12"/>
-			<lne id="904" begin="13" end="13"/>
-			<lne id="905" begin="13" end="14"/>
-			<lne id="906" begin="13" end="15"/>
-			<lne id="907" begin="16" end="18"/>
-			<lne id="908" begin="13" end="19"/>
-			<lne id="909" begin="7" end="20"/>
-			<lne id="910" begin="21" end="21"/>
-			<lne id="911" begin="21" end="22"/>
-			<lne id="912" begin="21" end="23"/>
-			<lne id="913" begin="21" end="24"/>
-			<lne id="914" begin="25" end="25"/>
-			<lne id="915" begin="21" end="26"/>
-			<lne id="916" begin="7" end="27"/>
-			<lne id="917" begin="28" end="28"/>
-			<lne id="918" begin="28" end="29"/>
-			<lne id="919" begin="7" end="30"/>
-			<lne id="920" begin="45" end="50"/>
+			<lne id="901" begin="7" end="7"/>
+			<lne id="902" begin="7" end="8"/>
+			<lne id="903" begin="9" end="11"/>
+			<lne id="904" begin="7" end="12"/>
+			<lne id="905" begin="13" end="13"/>
+			<lne id="906" begin="13" end="14"/>
+			<lne id="907" begin="13" end="15"/>
+			<lne id="908" begin="16" end="18"/>
+			<lne id="909" begin="13" end="19"/>
+			<lne id="910" begin="7" end="20"/>
+			<lne id="911" begin="21" end="21"/>
+			<lne id="912" begin="21" end="22"/>
+			<lne id="913" begin="21" end="23"/>
+			<lne id="914" begin="21" end="24"/>
+			<lne id="915" begin="25" end="25"/>
+			<lne id="916" begin="21" end="26"/>
+			<lne id="917" begin="7" end="27"/>
+			<lne id="918" begin="28" end="28"/>
+			<lne id="919" begin="28" end="29"/>
+			<lne id="920" begin="7" end="30"/>
+			<lne id="921" begin="45" end="50"/>
 		</linenumbertable>
 		<localvariabletable>
 			<lve slot="1" name="742" begin="6" end="52"/>
 			<lve slot="0" name="17" begin="0" end="53"/>
 		</localvariabletable>
 	</operation>
-	<operation name="921">
+	<operation name="922">
 		<context type="6"/>
 		<parameters>
 			<parameter name="19" type="336"/>
@@ -4303,11 +4304,11 @@
 			<pop/>
 		</code>
 		<linenumbertable>
-			<lne id="922" begin="11" end="11"/>
-			<lne id="923" begin="11" end="12"/>
-			<lne id="924" begin="11" end="13"/>
-			<lne id="925" begin="9" end="15"/>
-			<lne id="920" begin="8" end="16"/>
+			<lne id="923" begin="11" end="11"/>
+			<lne id="924" begin="11" end="12"/>
+			<lne id="925" begin="11" end="13"/>
+			<lne id="926" begin="9" end="15"/>
+			<lne id="921" begin="8" end="16"/>
 		</linenumbertable>
 		<localvariabletable>
 			<lve slot="3" name="790" begin="7" end="16"/>
@@ -4316,7 +4317,7 @@
 			<lve slot="1" name="463" begin="0" end="16"/>
 		</localvariabletable>
 	</operation>
-	<operation name="926">
+	<operation name="927">
 		<context type="6"/>
 		<parameters>
 		</parameters>
@@ -4345,8 +4346,8 @@
 			<load arg="19"/>
 			<get arg="738"/>
 			<get arg="810"/>
-			<get arg="38"/>
-			<push arg="927"/>
+			<get arg="840"/>
+			<push arg="928"/>
 			<call arg="158"/>
 			<call arg="717"/>
 			<load arg="19"/>
@@ -4377,34 +4378,34 @@
 			<enditerate/>
 		</code>
 		<linenumbertable>
-			<lne id="928" begin="7" end="7"/>
-			<lne id="929" begin="7" end="8"/>
-			<lne id="930" begin="9" end="11"/>
-			<lne id="931" begin="7" end="12"/>
-			<lne id="932" begin="13" end="13"/>
-			<lne id="933" begin="13" end="14"/>
-			<lne id="934" begin="13" end="15"/>
-			<lne id="935" begin="16" end="18"/>
-			<lne id="936" begin="13" end="19"/>
-			<lne id="937" begin="7" end="20"/>
-			<lne id="938" begin="21" end="21"/>
-			<lne id="939" begin="21" end="22"/>
-			<lne id="940" begin="21" end="23"/>
-			<lne id="941" begin="21" end="24"/>
-			<lne id="942" begin="25" end="25"/>
-			<lne id="943" begin="21" end="26"/>
-			<lne id="944" begin="7" end="27"/>
-			<lne id="945" begin="28" end="28"/>
-			<lne id="946" begin="28" end="29"/>
-			<lne id="947" begin="7" end="30"/>
-			<lne id="948" begin="45" end="50"/>
+			<lne id="929" begin="7" end="7"/>
+			<lne id="930" begin="7" end="8"/>
+			<lne id="931" begin="9" end="11"/>
+			<lne id="932" begin="7" end="12"/>
+			<lne id="933" begin="13" end="13"/>
+			<lne id="934" begin="13" end="14"/>
+			<lne id="935" begin="13" end="15"/>
+			<lne id="936" begin="16" end="18"/>
+			<lne id="937" begin="13" end="19"/>
+			<lne id="938" begin="7" end="20"/>
+			<lne id="939" begin="21" end="21"/>
+			<lne id="940" begin="21" end="22"/>
+			<lne id="941" begin="21" end="23"/>
+			<lne id="942" begin="21" end="24"/>
+			<lne id="943" begin="25" end="25"/>
+			<lne id="944" begin="21" end="26"/>
+			<lne id="945" begin="7" end="27"/>
+			<lne id="946" begin="28" end="28"/>
+			<lne id="947" begin="28" end="29"/>
+			<lne id="948" begin="7" end="30"/>
+			<lne id="949" begin="45" end="50"/>
 		</linenumbertable>
 		<localvariabletable>
 			<lve slot="1" name="742" begin="6" end="52"/>
 			<lve slot="0" name="17" begin="0" end="53"/>
 		</localvariabletable>
 	</operation>
-	<operation name="949">
+	<operation name="950">
 		<context type="6"/>
 		<parameters>
 			<parameter name="19" type="336"/>
@@ -4429,11 +4430,11 @@
 			<pop/>
 		</code>
 		<linenumbertable>
-			<lne id="950" begin="11" end="11"/>
-			<lne id="951" begin="11" end="12"/>
-			<lne id="952" begin="11" end="13"/>
-			<lne id="953" begin="9" end="15"/>
-			<lne id="948" begin="8" end="16"/>
+			<lne id="951" begin="11" end="11"/>
+			<lne id="952" begin="11" end="12"/>
+			<lne id="953" begin="11" end="13"/>
+			<lne id="954" begin="9" end="15"/>
+			<lne id="949" begin="8" end="16"/>
 		</linenumbertable>
 		<localvariabletable>
 			<lve slot="3" name="790" begin="7" end="16"/>

--- a/transformation/src/fr/inria/atlanmod/mogwai/transformation/files/ocl2gremlin.atl
+++ b/transformation/src/fr/inria/atlanmod/mogwai/transformation/files/ocl2gremlin.atl
@@ -404,7 +404,7 @@ rule propertyAttBooleanLastInComparison2steps {
 		prop : OCL!PropertyCallExp(
 			prop.referredProperty.oclIsTypeOf(OCL!EAttribute) and
 			prop.referredProperty.eType.oclIsTypeOf(OCL!EDataType) and
-			prop.referredProperty.eType.name = 'EBoolean'and
+			prop.referredProperty.eType.instanceClassName = 'java.lang.Boolean' and
 			prop.isLastInComparison()
 		)
 	to
@@ -439,7 +439,7 @@ rule propertyAttIntegerLastInComparison2steps {
 		prop : OCL!PropertyCallExp(
 			prop.referredProperty.oclIsTypeOf(OCL!EAttribute) and 
 			prop.referredProperty.eType.oclIsTypeOf(OCL!EDataType) and
-			prop.referredProperty.eType.name = 'EInt' and
+			prop.referredProperty.eType.instanceClassName = 'java.lang.Integer' and
 			prop.isLastInComparison()
 		)
 	to
@@ -453,7 +453,7 @@ rule propertyAttStringLastInComparison2steps {
 		prop : OCL!PropertyCallExp(
 			prop.referredProperty.oclIsTypeOf(OCL!EAttribute) and
 			prop.referredProperty.eType.oclIsTypeOf(OCL!EDataType) and
-			prop.referredProperty.eType.name = 'EString' and
+			prop.referredProperty.eType.instanceClassName = 'java.lang.String' and
 			prop.isLastInComparison()
 		)
 	to

--- a/transformation/src/fr/inria/atlanmod/mogwai/transformation/files/ocl2gremlin.atl
+++ b/transformation/src/fr/inria/atlanmod/mogwai/transformation/files/ocl2gremlin.atl
@@ -461,5 +461,3 @@ rule propertyAttStringLastInComparison2steps {
 			name <- prop.referredProperty.name	
 		)
 }
-
-

--- a/transformation/src/fr/inria/atlanmod/mogwai/transformation/files/ocl2gremlin.atl
+++ b/transformation/src/fr/inria/atlanmod/mogwai/transformation/files/ocl2gremlin.atl
@@ -319,7 +319,7 @@ rule varExp2steps {
 	to
 		va : Gremlin!VariableAccess(
 			name <- varExp.referredVariable.name.debug(),
-			nextElement <- varExp.getComposite().debug('test')
+			nextElement <- varExp.getComposite()
 		)
 }
 
@@ -330,7 +330,7 @@ rule varExpInCollect2steps {
 		)
 	to
 		id : Gremlin!IdentityStep(
-			nextElement <- varExp.getComposite().debug('aaaaaaaaaah')	
+			nextElement <- varExp.getComposite()
 		)
 }
 
@@ -404,7 +404,8 @@ rule propertyAttBooleanLastInComparison2steps {
 		prop : OCL!PropertyCallExp(
 			prop.referredProperty.oclIsTypeOf(OCL!EAttribute) and
 			prop.referredProperty.eType.oclIsTypeOf(OCL!EDataType) and
-			prop.referredProperty.eType.instanceClassName = 'java.lang.Boolean' and
+			(prop.referredProperty.eType.instanceClassName = 'java.lang.Boolean'
+				or prop.referredProperty.eType.instanceClassName = 'bool') and
 			prop.isLastInComparison()
 		)
 	to
@@ -439,7 +440,8 @@ rule propertyAttIntegerLastInComparison2steps {
 		prop : OCL!PropertyCallExp(
 			prop.referredProperty.oclIsTypeOf(OCL!EAttribute) and 
 			prop.referredProperty.eType.oclIsTypeOf(OCL!EDataType) and
-			prop.referredProperty.eType.instanceClassName = 'java.lang.Integer' and
+			(prop.referredProperty.eType.instanceClassName = 'java.lang.Integer' 
+				or prop.referredProperty.eType.instanceClassName = 'int') and
 			prop.isLastInComparison()
 		)
 	to


### PR DESCRIPTION
This is a proposed fix for one of the issues I had with my slightly more complex GraBaTs'09 query (see issue #4). Instead of limiting the script to the names of the standard Ecore datatypes, we can use the instance type names and also cover any compatible custom EDataType.